### PR TITLE
fix: barchart x axis tick values not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[4.4.2]
+  * Fix: BarChar xaxis - tick values not applied
 [4.4.1]
   * Fix grid: visible not used, y axis styling not applied.     
 [4.4.0]

--- a/src/BarChart.tsx
+++ b/src/BarChart.tsx
@@ -154,9 +154,9 @@ export const BarChart = ({
         labelOrientation={xAxisLabelOrientation}
         scale={direction === EChartDirection.HORIZONTAL ? "linear" : "band"}
         values={
-          direction === EChartDirection.HORIZONTAL ? undefined : data.bins
+          direction === EChartDirection.HORIZONTAL ? tickValues : data.bins
         }
-        domain={direction === EChartDirection.HORIZONTAL ? domain : undefined}
+        domain={direction === EChartDirection.HORIZONTAL ? domain : tickValues}
       />
     </Base>
   );

--- a/src/Barchart.spec.tsx
+++ b/src/Barchart.spec.tsx
@@ -2,10 +2,10 @@ import "@testing-library/jest-dom/extend-expect";
 
 import React from "react";
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 import { barChartData } from "../test/fixtures";
-import { BarChart } from "./BarChart";
+import { BarChart, EChartDirection } from "./BarChart";
 import { EGroupedBarLayout } from "./Histogram";
 
 beforeEach(() => {
@@ -21,7 +21,7 @@ test("BarChart", () => {
       height={600}
       id="demo"
       data={barChartData}
-    ></BarChart>,
+    ></BarChart>
   );
   expect(screen.getAllByRole("cell")).toHaveLength(42);
   expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "19");
@@ -37,7 +37,7 @@ test("BarChart Grouped overlaid layout", () => {
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}
       data={barChartData}
-    ></BarChart>,
+    ></BarChart>
   );
   expect(screen.getAllByRole("cell")).toHaveLength(42);
   expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "37");
@@ -57,7 +57,7 @@ test("BarChart Grouped overlaid layout, compact width", () => {
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}
       data={barChartData}
-    ></BarChart>,
+    ></BarChart>
   );
   expect(screen.getAllByRole("cell")).toHaveLength(42);
   expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "2");
@@ -67,4 +67,50 @@ test("BarChart Grouped overlaid layout, compact width", () => {
 
   expect(screen.getByTestId("chart-bar--41")).toHaveAttribute("width", "1");
   expect(screen.getByTestId("chart-bar--41")).toHaveAttribute("x", "49");
+});
+
+test("shows the x axis tick value when the chart is horizontal", () => {
+  render(
+    <BarChart
+      width={100}
+      height={600}
+      direction={EChartDirection.HORIZONTAL}
+      id="demo"
+      groupLayout={EGroupedBarLayout.OVERLAID}
+      data={barChartData}
+      tickValues={[33, 66, 99]}
+    ></BarChart>
+  );
+  const xaxis = screen.getByTestId("x-axis");
+  const yaxis = screen.getByTestId("y-axis");
+  expect(within(xaxis).getByText("33")).toBeInTheDocument();
+  expect(within(xaxis).getByText("66")).toBeInTheDocument();
+  expect(within(xaxis).getByText("99")).toBeInTheDocument();
+
+  expect(within(yaxis).queryByText("33")).not.toBeInTheDocument();
+  expect(within(yaxis).queryByText("66")).not.toBeInTheDocument();
+  expect(within(yaxis).queryByText("99")).not.toBeInTheDocument();
+});
+
+test("shows the y axis tick value when the chart is vertical", () => {
+  render(
+    <BarChart
+      width={100}
+      height={600}
+      direction={EChartDirection.VERTICAL}
+      id="demo"
+      groupLayout={EGroupedBarLayout.OVERLAID}
+      data={barChartData}
+      tickValues={[33, 66, 99]}
+    ></BarChart>
+  );
+  const xaxis = screen.getByTestId("x-axis");
+  const yaxis = screen.getByTestId("y-axis");
+  expect(within(yaxis).getByText("33")).toBeInTheDocument();
+  expect(within(yaxis).getByText("66")).toBeInTheDocument();
+  expect(within(yaxis).getByText("99")).toBeInTheDocument();
+
+  expect(within(xaxis).queryByText("33")).not.toBeInTheDocument();
+  expect(within(xaxis).queryByText("66")).not.toBeInTheDocument();
+  expect(within(xaxis).queryByText("99")).not.toBeInTheDocument();
 });

--- a/src/components/XAxis.tsx
+++ b/src/components/XAxis.tsx
@@ -20,7 +20,7 @@ const positionTick = (
   scale: any,
   i: number,
   inverse: boolean = false,
-  width = 10,
+  width = 10
 ) => {
   const offset = isOfType<ScaleBand<any>>(scale, "paddingInner")
     ? scale.bandwidth() / 2
@@ -82,6 +82,7 @@ export const XAxis = ({
   return (
     <g
       className="x-axis"
+      data-testid="x-axis"
       transform={`translate(${transform})`}
       fill="none"
       fontSize="10"

--- a/src/components/YAxis.tsx
+++ b/src/components/YAxis.tsx
@@ -21,7 +21,7 @@ export type TAxisValue = string | number;
 export type TAxisLabelFormat = (
   axis: "x" | "y",
   bin: string,
-  i: number,
+  i: number
 ) => string;
 
 export enum ELabelOrientation {
@@ -31,7 +31,7 @@ export enum ELabelOrientation {
 
 type TTickFormat = (
   label: string,
-  i: number,
+  i: number
 ) => {
   stroke: string;
   fontSize?: string;
@@ -108,8 +108,8 @@ export const buildScale = ({
       Scale = scaleLinear()
         .domain(
           extent(
-            domain ? [...(domain as number[])] : (values as number[]),
-          ) as any,
+            domain ? [...(domain as number[])] : (values as number[])
+          ) as any
         )
         .rangeRound(range);
       break;
@@ -131,7 +131,7 @@ export const buildScale = ({
       break;
     case "log":
       const d = extent(
-        domain ? [0, ...(domain as number[])] : (values as number[]),
+        domain ? [0, ...(domain as number[])] : (values as number[])
       ) as any;
       Scale = scaleSymlog()
         .clamp(true) // clamp values below 1 to be equal to 0
@@ -140,7 +140,7 @@ export const buildScale = ({
       break;
     case "time":
       const ex = extent(
-        domain ? [0, ...(domain as number[])] : (values as any[]),
+        domain ? [0, ...(domain as number[])] : (values as any[])
       ) as any;
       Scale = scaleTime().domain(ex).rangeRound(range);
       break;
@@ -153,7 +153,7 @@ const positionTick = (
   scale: any,
   height: number,
   i: number,
-  inverse: boolean = false,
+  inverse: boolean = false
 ) => {
   const offset = isOfType<ScaleBand<any>>(scale, "paddingInner")
     ? Math.floor(scale.bandwidth() / 2)
@@ -214,6 +214,7 @@ export const YAxis = ({
   return (
     <g
       className="y-axis"
+      data-testid="y-axis"
       transform={`translate${transform}`}
       fill="none"
       fontSize="10"


### PR DESCRIPTION
tick values were only being set on the yaxis 

![image](https://github.com/infosum/cl-react-graph/assets/28268/724b557d-7322-4678-8fa7-f4bf8500b08f)
