### PR TITLE
Bars as rects

### DIFF
--- a/docs-src/src/pages/bar-chart.tsx
+++ b/docs-src/src/pages/bar-chart.tsx
@@ -152,6 +152,63 @@ const data: BarChartData = {
     },
   ],
 };
+// const data: BarChartData = {
+//   bins: ["Age 0-17", "Age 18-40", "Age 40+"],
+//   counts: [
+//     {
+//       label: "Male",
+//       data: [27.77777777777778, 55.55555555555556, 16.666666666666664],
+//     },
+//     {
+//       label: "Female",
+//       data: [11.11111111111111, 38.88888888888889, 50],
+//     },
+// {
+//   label: "quia",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "repellat",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "qui",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "dolorum",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "nostrum",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "cupiditate",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "blanditiis",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "et",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "hi",
+//   data: [27.77777777777778, 0, 0],
+// },
+// {
+//   label: "there",
+//   data: [38.88888888888889, 0, 0],
+// },
+// {
+//   label: "bob",
+//   data: [0, 16.666666666666664, 0],
+// },
+//   ],
+// };
 
 const lineStyle: SVGLineStyle = {
   fill: "#000",
@@ -205,7 +262,24 @@ const BarChartExample = () => {
             data={data}
             height={400}
             tickValues={[0, 40000, 89200]}
-            grid={grid}
+            grid={{
+              x: {
+                height: 1,
+                style: {
+                  fill: "hsla(208, 32%, 91%, 1)",
+                  stroke: "hsla(208, 32%, 91%, 1)",
+                  strokeDasharray: "2 2",
+                  strokeOpacity: 1,
+                },
+                ticks: 4,
+                visible: true,
+              },
+              y: {
+                style: {},
+                ticks: 10,
+                visible: false,
+              },
+            }}
             colorScheme={[theme.brightBlue800, theme.green900]}
             groupLayout={EGroupedBarLayout.GROUPED}
             axis={{

--- a/docs-src/src/pages/bar-chart.tsx
+++ b/docs-src/src/pages/bar-chart.tsx
@@ -104,6 +104,7 @@ const MyComponent = () => {
         }}
         showLabels={[false, true]}
         direction={EChartDirection.HORIZONTAL}
+        bars={{radius: 4}}
         data={data}
         height={400}
         tickValues={[0, 40000, 89200]}
@@ -152,63 +153,6 @@ const data: BarChartData = {
     },
   ],
 };
-// const data: BarChartData = {
-//   bins: ["Age 0-17", "Age 18-40", "Age 40+"],
-//   counts: [
-//     {
-//       label: "Male",
-//       data: [27.77777777777778, 55.55555555555556, 16.666666666666664],
-//     },
-//     {
-//       label: "Female",
-//       data: [11.11111111111111, 38.88888888888889, 50],
-//     },
-// {
-//   label: "quia",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "repellat",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "qui",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "dolorum",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "nostrum",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "cupiditate",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "blanditiis",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "et",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "hi",
-//   data: [27.77777777777778, 0, 0],
-// },
-// {
-//   label: "there",
-//   data: [38.88888888888889, 0, 0],
-// },
-// {
-//   label: "bob",
-//   data: [0, 16.666666666666664, 0],
-// },
-//   ],
-// };
 
 const lineStyle: SVGLineStyle = {
   fill: "#000",
@@ -259,6 +203,8 @@ const BarChartExample = () => {
             }}
             showLabels={[false, true]}
             direction={EChartDirection.HORIZONTAL}
+            groupLayout={EGroupedBarLayout.OVERLAID}
+            bars={{ radius: 4 }}
             data={data}
             height={400}
             tickValues={[0, 40000, 89200]}
@@ -281,7 +227,6 @@ const BarChartExample = () => {
               },
             }}
             colorScheme={[theme.brightBlue800, theme.green900]}
-            groupLayout={EGroupedBarLayout.GROUPED}
             axis={{
               x: {
                 labelOrientation: ELabelOrientation.VERTICAL,

--- a/docs-src/src/pages/histogram.tsx
+++ b/docs-src/src/pages/histogram.tsx
@@ -151,6 +151,7 @@ const HistogramExample = () => {
   return (
     <Layout>
       <h2>Histogram Chart</h2>
+      <h3>Horizontal</h3>
       <TwoColumns>
         <div ref={ref}>
           <Histogram
@@ -177,6 +178,60 @@ const HistogramExample = () => {
           />
         </div>
         <JSXCode exampleCode={exampleCode} />
+      </TwoColumns>
+      <h3>Vertical</h3>
+
+      <TwoColumns>
+        <div ref={ref}>
+          <Histogram
+            animation={{
+              duration: 300,
+            }}
+            showLabels={[true, true]}
+            LabelComponent={({ item }) => {
+              return (
+                <g transform="translate(0, -10)">
+                  <g>
+                    <circle dy={10} r={4} fill="red"></circle>
+                    <text dx="10">{item.percentage}</text>
+                  </g>
+                </g>
+              );
+            }}
+            direction={EChartDirection.VERTICAL}
+            data={data}
+            height={400}
+            grid={grid}
+            xAxisLabelOrientation={ELabelOrientation.HORIZONTAL}
+            width={width}
+          />
+        </div>
+        <JSXCode
+          exampleCode={`
+<Histogram
+  animation={{
+    duration: 300,
+  }}
+  showLabels={[true, true]}
+  LabelComponent={({ item }) => {
+    return (
+      <g transform="translate(0, -10)">
+        <g>
+          <circle dy={10} r={4} fill="red"></circle>
+          <text dx="10">{item.percentage}</text>
+        </g>
+      </g>
+    );
+  }}
+  direction={EChartDirection.VERTICAL}
+  data={data}
+  height={400}
+  grid={grid}
+  xAxisLabelOrientation={ELabelOrientation.HORIZONTAL}
+  width={width}
+/>
+        `}
+        />
       </TwoColumns>
     </Layout>
   );

--- a/docs-src/src/pages/joyplot.tsx
+++ b/docs-src/src/pages/joyplot.tsx
@@ -100,6 +100,9 @@ const JoyPlotExample = () => {
             data={data}
             title="In market for a car"
             xAxisHeight={20}
+            bars={{
+              radius: 4,
+            }}
             colorScheme={[theme.green900]}
             width={width}
             height={data.length * 150}

--- a/docs-src/src/pages/tornado.tsx
+++ b/docs-src/src/pages/tornado.tsx
@@ -50,7 +50,7 @@ const MyComponent = () => {
     splitBins={['Male', 'Female']}
     groupLayout={EGroupedBarLayout.OVERLAID}
     width={width}
-    height={500}
+    height={350}
     splitAxisHeight={50}
     xAxisHeight={20}
     colorScheme={['hsla(140, 60%, 88%, 1)', 'hsla(208, 69%, 66%, 1)']}
@@ -67,19 +67,15 @@ const data: ITornadoProps["data"] = {
     {
       label: "Background",
       data: [
-        [9700],
-        [],
-        // [1000, 2600, 5100, 9700, 8400, 6700], // Male bin 1, Male bin 2,
-        // [2002, 2100, 4700, 8700, 4900, 1400], // Female bin 1, Female bin 2,
+        [1000, 2600, 5100, 9700, 8400, 6700], // Male bin 1, Male bin 2,
+        [2002, 2100, 4700, 8700, 4900, 1400], // Female bin 1, Female bin 2,
       ],
     },
     {
       label: "Foreground",
       data: [
-        [200],
-        [],
-        // [200, 560, 510, 970, 840, 670], // Male bin 1, Male bin 2,
-        // [1000, 5500, 470, 870, 490, 140], // Female bin 1, Female bin 2,
+        [200, 560, 510, 970, 840, 670], // Male bin 1, Male bin 2,
+        [1000, 5500, 470, 870, 490, 140], // Female bin 1, Female bin 2,
       ],
     },
   ],
@@ -91,88 +87,188 @@ const TornadoExample = () => {
     <Layout>
       <h2>Tornado Chart</h2>
 
+      <h3>Horizontal Overlaid</h3>
       <TwoColumns>
         <div ref={ref}>
           <TornadoChart
             data={data}
             splitBins={["Male", "Female"]}
+            bars={{ radius: 4 }}
             groupLayout={EGroupedBarLayout.OVERLAID}
+            direction={EChartDirection.HORIZONTAL}
             width={width}
-            height={500}
+            height={350}
             splitAxisHeight={50}
             xAxisHeight={20}
             colorScheme={[theme.green900, theme.brightBlue500]}
-            direction={EChartDirection.VERTICAL}
             showBinPercentages={false}
           />
         </div>
         <JSXCode exampleCode={exampleCode} />
       </TwoColumns>
 
-      <TornadoChart
-        data={data}
-        splitBins={["Male", "Female"]}
-        groupLayout={EGroupedBarLayout.GROUPED}
-        width={width}
-        height={500}
-        splitAxisHeight={50}
-        xAxisHeight={20}
-        colorScheme={[theme.green900, theme.brightBlue500]}
-        direction={EChartDirection.VERTICAL}
-        showBinPercentages={false}
-      />
+      <h3>Horizontal Stacked</h3>
+      <TwoColumns>
+        <TornadoChart
+          data={data}
+          splitBins={["Male", "Female"]}
+          bars={{ radius: 4 }}
+          direction={EChartDirection.HORIZONTAL}
+          groupLayout={EGroupedBarLayout.STACKED}
+          width={width}
+          height={350}
+          splitAxisHeight={50}
+          xAxisHeight={20}
+          colorScheme={[theme.green900, theme.brightBlue500]}
+          showBinPercentages={false}
+        />
+        <JSXCode
+          exampleCode={`
+  <TornadoChart
+    data={data}
+    splitBins={["Male", "Female"]}
+    bars={{radius: 4}}
+    direction={EChartDirection.HORIZONTAL}
+    groupLayout={EGroupedBarLayout.STACKED}
+    width={width}
+    height={350}
+    splitAxisHeight={50}
+    xAxisHeight={20}
+    colorScheme={[theme.green900, theme.brightBlue500]}
+    showBinPercentages={false}
+  />`}
+        />
+      </TwoColumns>
+      <h3>Horizontal Grouped</h3>
+      <TwoColumns>
+        <TornadoChart
+          data={data}
+          splitBins={["Male", "Female"]}
+          bars={{ radius: 4 }}
+          groupLayout={EGroupedBarLayout.GROUPED}
+          direction={EChartDirection.HORIZONTAL}
+          width={width}
+          height={350}
+          splitAxisHeight={50}
+          xAxisHeight={20}
+          colorScheme={[theme.green900, theme.brightBlue500]}
+          showBinPercentages={false}
+        />
+        <JSXCode
+          exampleCode={`
+  <TornadoChart
+    data={data}
+    splitBins={["Male", "Female"]}
+    bars={{radius: 4}}
+    direction={EChartDirection.HORIZONTAL}
+    groupLayout={EGroupedBarLayout.GROUPED}
+    width={width}
+    height={350}
+    splitAxisHeight={50}
+    xAxisHeight={20}
+    colorScheme={[theme.green900, theme.brightBlue500]}
+    showBinPercentages={false}
+  />`}
+        />
+      </TwoColumns>
 
-      <TornadoChart
-        data={data}
-        splitBins={["Male", "Female"]}
-        groupLayout={EGroupedBarLayout.STACKED}
-        width={width}
-        height={500}
-        splitAxisHeight={50}
-        xAxisHeight={20}
-        colorScheme={[theme.green900, theme.brightBlue500]}
-        direction={EChartDirection.VERTICAL}
-        showBinPercentages={false}
-      />
+      <h3>Vertical Overlaid</h3>
+      <TwoColumns>
+        <TornadoChart
+          data={data}
+          splitBins={["Male", "Female"]}
+          bars={{ radius: 4 }}
+          groupLayout={EGroupedBarLayout.OVERLAID}
+          direction={EChartDirection.VERTICAL}
+          width={width}
+          height={350}
+          splitAxisHeight={50}
+          xAxisHeight={20}
+          colorScheme={[theme.green900, theme.brightBlue500]}
+          showBinPercentages={false}
+        />
+        <JSXCode
+          exampleCode={`
+  <TornadoChart
+    data={data}
+    splitBins={["Male", "Female"]}
+    bars={{radius: 4}}
+    direction={EChartDirection.VERTICAL}
+    groupLayout={EGroupedBarLayout.OVERLAID}
+    width={width}
+    height={350}
+    splitAxisHeight={50}
+    xAxisHeight={20}
+    colorScheme={[theme.green900, theme.brightBlue500]}
+    showBinPercentages={false}
+  />`}
+        />
+      </TwoColumns>
 
-      <TornadoChart
-        data={data}
-        splitBins={["Male", "Female"]}
-        groupLayout={EGroupedBarLayout.OVERLAID}
-        width={width}
-        height={500}
-        splitAxisHeight={50}
-        xAxisHeight={20}
-        colorScheme={[theme.green900, theme.brightBlue500]}
-        direction={EChartDirection.HORIZONTAL}
-        showBinPercentages={false}
-      />
-
-      <TornadoChart
-        data={data}
-        splitBins={["Male", "Female"]}
-        groupLayout={EGroupedBarLayout.GROUPED}
-        width={width}
-        height={500}
-        splitAxisHeight={50}
-        xAxisHeight={20}
-        colorScheme={[theme.green900, theme.brightBlue500]}
-        direction={EChartDirection.HORIZONTAL}
-        showBinPercentages={false}
-      />
-
-      <TornadoChart
-        data={data}
-        splitBins={["Male", "Female"]}
-        groupLayout={EGroupedBarLayout.STACKED}
-        width={width}
-        height={500}
-        splitAxisHeight={50}
-        xAxisHeight={20}
-        colorScheme={[theme.green900, theme.brightBlue500]}
-        direction={EChartDirection.HORIZONTAL}
-        showBinPercentages={false}
-      />
+      <h3>Vertical Stacked</h3>
+      <TwoColumns>
+        <TornadoChart
+          data={data}
+          splitBins={["Male", "Female"]}
+          bars={{ radius: 4 }}
+          groupLayout={EGroupedBarLayout.STACKED}
+          direction={EChartDirection.VERTICAL}
+          width={width}
+          height={350}
+          splitAxisHeight={50}
+          xAxisHeight={20}
+          colorScheme={[theme.green900, theme.brightBlue500]}
+          showBinPercentages={false}
+        />
+        <JSXCode
+          exampleCode={`
+  <TornadoChart
+    data={data}
+    splitBins={["Male", "Female"]}
+    bars={{radius: 4}}
+    direction={EChartDirection.VERTICAL}
+    groupLayout={EGroupedBarLayout.STACKED}
+    width={width}
+    height={350}
+    splitAxisHeight={50}
+    xAxisHeight={20}
+    colorScheme={[theme.green900, theme.brightBlue500]}
+    showBinPercentages={false}
+  />`}
+        />
+      </TwoColumns>
+      <h3>Vertical Grouped</h3>
+      <TwoColumns>
+        <TornadoChart
+          data={data}
+          splitBins={["Male", "Female"]}
+          bars={{ radius: 4 }}
+          direction={EChartDirection.VERTICAL}
+          groupLayout={EGroupedBarLayout.GROUPED}
+          width={width}
+          height={500}
+          splitAxisHeight={50}
+          xAxisHeight={20}
+          colorScheme={[theme.green900, theme.brightBlue500]}
+          showBinPercentages={false}
+        />
+        <JSXCode
+          exampleCode={`
+  <TornadoChart
+    data={data}
+    splitBins={["Male", "Female"]}
+    bars={{radius: 4}}
+    direction={EChartDirection.VERTICAL}
+    groupLayout={EGroupedBarLayout.GROUPED}
+    width={width}
+    height={500}
+    splitAxisHeight={50}
+    xAxisHeight={20}
+    colorScheme={[theme.green900, theme.brightBlue500]}
+    showBinPercentages={false}
+  />`}
+        />
+      </TwoColumns>
     </Layout>
   );
 };

--- a/docs-src/src/pages/tornado.tsx
+++ b/docs-src/src/pages/tornado.tsx
@@ -67,15 +67,19 @@ const data: ITornadoProps["data"] = {
     {
       label: "Background",
       data: [
-        [200, 2600, 5100, 9700, 8400, 6700], // Male bin 1, Male bin 2,
-        [2002, 2100, 4700, 8700, 4900, 1400], // Female bin 1, Female bin 2,
+        [9700],
+        [],
+        // [1000, 2600, 5100, 9700, 8400, 6700], // Male bin 1, Male bin 2,
+        // [2002, 2100, 4700, 8700, 4900, 1400], // Female bin 1, Female bin 2,
       ],
     },
     {
       label: "Foreground",
       data: [
-        [100, 260, 510, 970, 840, 670], // Male bin 1, Male bin 2,
-        [1000, 5500, 470, 870, 490, 140], // Female bin 1, Female bin 2,
+        [200],
+        [],
+        // [200, 560, 510, 970, 840, 670], // Male bin 1, Male bin 2,
+        // [1000, 5500, 470, 870, 490, 140], // Female bin 1, Female bin 2,
       ],
     },
   ],
@@ -98,12 +102,77 @@ const TornadoExample = () => {
             splitAxisHeight={50}
             xAxisHeight={20}
             colorScheme={[theme.green900, theme.brightBlue500]}
-            direction={EChartDirection.HORIZONTAL}
+            direction={EChartDirection.VERTICAL}
             showBinPercentages={false}
           />
         </div>
         <JSXCode exampleCode={exampleCode} />
       </TwoColumns>
+
+      <TornadoChart
+        data={data}
+        splitBins={["Male", "Female"]}
+        groupLayout={EGroupedBarLayout.GROUPED}
+        width={width}
+        height={500}
+        splitAxisHeight={50}
+        xAxisHeight={20}
+        colorScheme={[theme.green900, theme.brightBlue500]}
+        direction={EChartDirection.VERTICAL}
+        showBinPercentages={false}
+      />
+
+      <TornadoChart
+        data={data}
+        splitBins={["Male", "Female"]}
+        groupLayout={EGroupedBarLayout.STACKED}
+        width={width}
+        height={500}
+        splitAxisHeight={50}
+        xAxisHeight={20}
+        colorScheme={[theme.green900, theme.brightBlue500]}
+        direction={EChartDirection.VERTICAL}
+        showBinPercentages={false}
+      />
+
+      <TornadoChart
+        data={data}
+        splitBins={["Male", "Female"]}
+        groupLayout={EGroupedBarLayout.OVERLAID}
+        width={width}
+        height={500}
+        splitAxisHeight={50}
+        xAxisHeight={20}
+        colorScheme={[theme.green900, theme.brightBlue500]}
+        direction={EChartDirection.HORIZONTAL}
+        showBinPercentages={false}
+      />
+
+      <TornadoChart
+        data={data}
+        splitBins={["Male", "Female"]}
+        groupLayout={EGroupedBarLayout.GROUPED}
+        width={width}
+        height={500}
+        splitAxisHeight={50}
+        xAxisHeight={20}
+        colorScheme={[theme.green900, theme.brightBlue500]}
+        direction={EChartDirection.HORIZONTAL}
+        showBinPercentages={false}
+      />
+
+      <TornadoChart
+        data={data}
+        splitBins={["Male", "Female"]}
+        groupLayout={EGroupedBarLayout.STACKED}
+        width={width}
+        height={500}
+        splitAxisHeight={50}
+        xAxisHeight={20}
+        colorScheme={[theme.green900, theme.brightBlue500]}
+        direction={EChartDirection.HORIZONTAL}
+        showBinPercentages={false}
+      />
     </Layout>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cl-react-graph",
-  "version": "4.5.3",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cl-react-graph",
-      "version": "4.5.3",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cl-react-graph",
-  "version": "4.5.3",
+  "version": "5.0.0",
   "description": "React D3 Charts",
   "main": "./dist/index.js",
   "types": "./dist/types/src/index.d.ts",

--- a/src/BarChart.tsx
+++ b/src/BarChart.tsx
@@ -64,12 +64,10 @@ type Props = {
   visible?: Record<string, boolean>;
   width: number;
   xAxisHeight?: number;
-  /** @deprecated use axis.x.labelOrientation */
-  xAxisLabelOrientation?: ELabelOrientation;
   yAxisWidth?: number;
   bars?: {
-    rx?: number;
-    ry?: number;
+    /** @description radius (px) of bar rounded end's curves. Default 0 - no rounded ends */
+    radius?: number;
   };
   /** @description nodes rendered after/above the bars */
   labels?: string[];
@@ -94,7 +92,6 @@ export const BarChart = ({
   visible,
   width,
   xAxisHeight,
-  xAxisLabelOrientation = ELabelOrientation.HORIZONTAL,
   yAxisWidth,
   tickValues,
   bars,
@@ -155,8 +152,7 @@ export const BarChart = ({
         values={data.counts}
         visible={visible}
         width={width - yAxisWidth}
-        rx={bars?.rx ?? 0}
-        ry={bars?.ry ?? 0}
+        radius={bars?.radius ?? 0}
       />
 
       <YAxis
@@ -182,7 +178,7 @@ export const BarChart = ({
         padding={padding}
         left={yAxisWidth}
         labelFormat={axisLabelFormat}
-        labelOrientation={axis?.x?.labelOrientation ?? xAxisLabelOrientation}
+        labelOrientation={axis?.x?.labelOrientation}
         scale={direction === EChartDirection.HORIZONTAL ? "linear" : "band"}
         values={
           direction === EChartDirection.HORIZONTAL ? tickValues : data.bins

--- a/src/Barchart.spec.tsx
+++ b/src/Barchart.spec.tsx
@@ -19,6 +19,7 @@ test("BarChart", () => {
     <BarChart
       width={1000}
       height={600}
+      bars={{ radius: 4 }}
       id="demo"
       data={barChartData}
     ></BarChart>
@@ -30,7 +31,7 @@ test("BarChart", () => {
   );
   expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
     "d",
-    "m11 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+    "m11 500 v0 a4,4 0 0 1 4,-4 h11 a4 4 0 0 1 4 4 v0 h-19 z"
   );
   expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
     "data-percentage",
@@ -38,7 +39,7 @@ test("BarChart", () => {
   );
   expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
     "d",
-    "m56 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+    "m56 500 v0 a4,4 0 0 1 4,-4 h11 a4 4 0 0 1 4 4 v0 h-19 z"
   );
   expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
     "data-percentage",
@@ -46,7 +47,7 @@ test("BarChart", () => {
   );
   expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
     "d",
-    "m101 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+    "m101 500 v0 a4,4 0 0 1 4,-4 h11 a4 4 0 0 1 4 4 v0 h-19 z"
   );
 });
 
@@ -56,6 +57,7 @@ test("BarChart Grouped overlaid layout", () => {
     <BarChart
       width={1000}
       height={600}
+      bars={{ radius: 4 }}
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}
       data={barChartData}
@@ -64,20 +66,20 @@ test("BarChart Grouped overlaid layout", () => {
   expect(screen.getAllByRole("cell")).toHaveLength(84);
   expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
     "d",
-    "m12 500 v0 a10 10 0 0 1 10 -10 h17 a10 10 0 0 1 10 10 v0 h-17"
+    "m12 500 v0 a4,4 0 0 1 4,-4 h29 a4 4 0 0 1 4 4 v0 h-37 z"
   );
   expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
     "d",
-    "m57 500 v0 a10 10 0 0 1 10 -10 h17 a10 10 0 0 1 10 10 v0 h-17"
+    "m57 500 v0 a4,4 0 0 1 4,-4 h29 a4 4 0 0 1 4 4 v0 h-37 z"
   );
   expect(screen.getByTestId("chart-bar--20")).toHaveAttribute(
     "d",
-    "m912 500 v0 a10 10 0 0 1 10 -10 h17 a10 10 0 0 1 10 10 v0 h-17"
+    "m912 500 v0 a4,4 0 0 1 4,-4 h29 a4 4 0 0 1 4 4 v0 h-37 z"
   );
 
   expect(screen.getByTestId("chart-bar--41")).toHaveAttribute(
     "d",
-    "m921 500 v0 a0 0 0 0 1 0 -0 h18 a0 0 0 0 1 0 0 v0 h-18"
+    "m921 500 v0 a4,4 0 0 1 4,-4 h10 a4 4 0 0 1 4 4 v0 h-18 z"
   );
 });
 
@@ -86,6 +88,7 @@ test("BarChart Grouped overlaid layout, compact width", () => {
     <BarChart
       width={100}
       height={600}
+      bars={{ radius: 4 }}
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}
       data={barChartData}
@@ -98,22 +101,19 @@ test("BarChart Grouped overlaid layout, compact width", () => {
   );
   expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
     "d",
-    "m9 500 v0 a0 0 0 0 1 0 -0 h2 a0 0 0 0 1 0 0 v0 h-2"
+    "m9 500 v0 a4,4 0 0 1 4,-4 h-6 a4 4 0 0 1 4 4 v0 h-2 z"
   );
   expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
     "d",
-    "m11 500 v0 a0 0 0 0 1 0 -0 h2 a0 0 0 0 1 0 0 v0 h-2"
+    "m11 500 v0 a4,4 0 0 1 4,-4 h-6 a4 4 0 0 1 4 4 v0 h-2 z"
   );
   expect(screen.getByTestId("chart-bar--20")).toHaveAttribute(
     "d",
-    "m49 500 v0 a0 0 0 0 1 0 -0 h2 a0 0 0 0 1 0 0 v0 h-2"
+    "m49 500 v0 a4,4 0 0 1 4,-4 h-6 a4 4 0 0 1 4 4 v0 h-2 z"
   );
-  // expect(screen.getByTestId("chart-bar--1")).toHaveAttribute("width", "2");
-  // expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("width", "2");
-  // expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("x", "49");
   expect(screen.getByTestId("chart-bar--41")).toHaveAttribute(
     "d",
-    "m49 500 v0 a0 0 0 0 1 0 -0 h1 a0 0 0 0 1 0 0 v0 h-1"
+    "m49 500 v0 a4,4 0 0 1 4,-4 h-7 a4 4 0 0 1 4 4 v0 h-1 z"
   );
 });
 
@@ -122,6 +122,7 @@ test("shows the x axis tick value when the chart is horizontal", () => {
     <BarChart
       width={100}
       height={600}
+      bars={{ radius: 4 }}
       direction={EChartDirection.HORIZONTAL}
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}
@@ -145,6 +146,7 @@ test("shows the y axis tick value when the chart is vertical", () => {
     <BarChart
       width={100}
       height={600}
+      bars={{ radius: 4 }}
       direction={EChartDirection.VERTICAL}
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}
@@ -168,6 +170,7 @@ test("iterates over color scheme if more values present than colors", () => {
     <BarChart
       width={100}
       height={600}
+      bars={{ radius: 4 }}
       direction={EChartDirection.VERTICAL}
       id="demo"
       groupLayout={EGroupedBarLayout.OVERLAID}

--- a/src/Barchart.spec.tsx
+++ b/src/Barchart.spec.tsx
@@ -24,11 +24,33 @@ test("BarChart", () => {
     ></BarChart>
   );
   expect(screen.getAllByRole("cell")).toHaveLength(84);
-  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "19");
-  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute("width", "19");
-  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute("width", "19");
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "data-percentage",
+    "5.89"
+  );
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "d",
+    "m11 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "data-percentage",
+    "5.27"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "d",
+    "m56 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+  );
+  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+    "data-percentage",
+    "1.34"
+  );
+  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+    "d",
+    "m101 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+  );
 });
 
+t: HTMLInputElement;
 test("BarChart Grouped overlaid layout", () => {
   render(
     <BarChart
@@ -40,13 +62,23 @@ test("BarChart Grouped overlaid layout", () => {
     ></BarChart>
   );
   expect(screen.getAllByRole("cell")).toHaveLength(84);
-  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "37");
-  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute("width", "37");
-  expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("width", "37");
-  expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("x", "912");
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "d",
+    "m12 500 v0 a10 10 0 0 1 10 -10 h17 a10 10 0 0 1 10 10 v0 h-17"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "d",
+    "m57 500 v0 a10 10 0 0 1 10 -10 h17 a10 10 0 0 1 10 10 v0 h-17"
+  );
+  expect(screen.getByTestId("chart-bar--20")).toHaveAttribute(
+    "d",
+    "m912 500 v0 a10 10 0 0 1 10 -10 h17 a10 10 0 0 1 10 10 v0 h-17"
+  );
 
-  expect(screen.getByTestId("chart-bar--41")).toHaveAttribute("width", "18");
-  expect(screen.getByTestId("chart-bar--41")).toHaveAttribute("x", "921");
+  expect(screen.getByTestId("chart-bar--41")).toHaveAttribute(
+    "d",
+    "m921 500 v0 a0 0 0 0 1 0 -0 h18 a0 0 0 0 1 0 0 v0 h-18"
+  );
 });
 
 test("BarChart Grouped overlaid layout, compact width", () => {
@@ -60,13 +92,29 @@ test("BarChart Grouped overlaid layout, compact width", () => {
     ></BarChart>
   );
   expect(screen.getAllByRole("cell")).toHaveLength(84);
-  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "2");
-  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute("width", "2");
-  expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("width", "2");
-  expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("x", "49");
-
-  expect(screen.getByTestId("chart-bar--41")).toHaveAttribute("width", "1");
-  expect(screen.getByTestId("chart-bar--41")).toHaveAttribute("x", "49");
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "data-percentage",
+    "5.89"
+  );
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "d",
+    "m9 500 v0 a0 0 0 0 1 0 -0 h2 a0 0 0 0 1 0 0 v0 h-2"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "d",
+    "m11 500 v0 a0 0 0 0 1 0 -0 h2 a0 0 0 0 1 0 0 v0 h-2"
+  );
+  expect(screen.getByTestId("chart-bar--20")).toHaveAttribute(
+    "d",
+    "m49 500 v0 a0 0 0 0 1 0 -0 h2 a0 0 0 0 1 0 0 v0 h-2"
+  );
+  // expect(screen.getByTestId("chart-bar--1")).toHaveAttribute("width", "2");
+  // expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("width", "2");
+  // expect(screen.getByTestId("chart-bar--20")).toHaveAttribute("x", "49");
+  expect(screen.getByTestId("chart-bar--41")).toHaveAttribute(
+    "d",
+    "m49 500 v0 a0 0 0 0 1 0 -0 h1 a0 0 0 0 1 0 0 v0 h-1"
+  );
 });
 
 test("shows the x axis tick value when the chart is horizontal", () => {

--- a/src/Histogram.spec.tsx
+++ b/src/Histogram.spec.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 
 import { histogramData } from "../test/fixtures";
+import { EChartDirection } from "./";
 import { Histogram } from "./Histogram";
 
 beforeEach(() => {
@@ -13,10 +14,50 @@ beforeEach(() => {
   };
 });
 
-test("Histogram", () => {
-  render(<Histogram width={100} height={200} data={histogramData}></Histogram>);
+test("Histogram: Vertical", () => {
+  render(
+    <Histogram
+      width={100}
+      direction={EChartDirection.VERTICAL}
+      height={200}
+      data={histogramData}
+    ></Histogram>
+  );
   expect(screen.getAllByRole("cell")).toHaveLength(6);
-  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute("width", "10");
-  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute("width", "20");
-  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute("width", "30");
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "d",
+    "m0 100 v0 a4,4 0 0 1 4,-4 h2 a4 4 0 0 1 4 4 v0 h-25 z"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "d",
+    "m10 100 v0 a4,4 0 0 1 4,-4 h12 a4 4 0 0 1 4 4 v0 h-100 z"
+  );
+  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+    "d",
+    "m30 100 v0 a4,4 0 0 1 4,-4 h22 a4 4 0 0 1 4 4 v0 h-75 z"
+  );
+});
+
+test("Histogram: Horizontal", () => {
+  render(
+    <Histogram
+      width={500}
+      direction={EChartDirection.HORIZONTAL}
+      height={500}
+      data={histogramData}
+    ></Histogram>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(6);
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "d",
+    "m0 383 h0 a4 4 0 0 1 4 4 v69 a4 4 0 0 1 -4 4 h-0  v-69"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "d",
+    "m0 230 h0 a4 4 0 0 1 4 4 v145 a4 4 0 0 1 -4 4 h-0  v-145"
+  );
+  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+    "d",
+    "m0 0 h0 a4 4 0 0 1 4 4 v222 a4 4 0 0 1 -4 4 h-0  v-222"
+  );
 });

--- a/src/Histogram.tsx
+++ b/src/Histogram.tsx
@@ -122,8 +122,7 @@ export type Props = {
   title?: string;
   description?: string;
   bars?: {
-    rx?: number;
-    ry?: number;
+    radius?: number;
   };
 };
 
@@ -206,8 +205,7 @@ export const Histogram = ({
         continuousDomain={continuousDomain}
         tip={tip}
         visible={visible}
-        rx={bars?.rx ?? 0}
-        ry={bars?.ry ?? 0}
+        radius={bars?.radius ?? 0}
       />
 
       <YAxis

--- a/src/JoyPlot.tsx
+++ b/src/JoyPlot.tsx
@@ -29,6 +29,10 @@ export type Props = {
   yAxisWidth?: number;
   titleHeight?: number;
   titleLayout?: ELabelOrientation;
+  bars?: {
+    /** @description radius (px) of bar rounded end's curves. Default 0 - no rounded ends */
+    radius?: number;
+  };
 };
 
 /**
@@ -49,6 +53,7 @@ export const JoyPlot = ({
   title,
   titleHeight = 40,
   titleLayout = ELabelOrientation.HORIZONTAL,
+  bars,
 }: Props) => {
   const { chartHeight, bins, domain, values } = useJoyPlot({
     data,
@@ -141,6 +146,7 @@ export const JoyPlot = ({
               direction={direction}
               tip={tip}
               width={xWidth}
+              radius={bars?.radius ?? 0}
             />
           </g>
         );

--- a/src/Tornado.spec.tsx
+++ b/src/Tornado.spec.tsx
@@ -176,7 +176,6 @@ test("Tornado: Horizontal grouped", () => {
   );
 });
 
-////
 
 test("Tornado: Vertical overlay", () => {
   render(

--- a/src/Tornado.spec.tsx
+++ b/src/Tornado.spec.tsx
@@ -21,54 +21,300 @@ const data: Props["data"] = {
     {
       label: "Background",
       data: [
-        [2001], // Male bin 1, Male bin 2,
-        [2002], // Female bin 1, Female bin 2,
+        [1000, 2000], // Male bin 1, Male bin 2,
+        [1500, 1500], // Female bin 1, Female bin 2,
       ],
     },
-    // {
-    //   label: "Foreground",
-    //   data: [
-    //     [100, 260, 510, 970, 840, 670], // Male bin 1, Male bin 2,
-    //     [1000, 5500, 470, 870, 490, 140], // Female bin 1, Female bin 2,
-    //   ],
-    // },
+    {
+      label: "Foreground",
+      data: [
+        [500, 400], // Male bin 1, Male bin 2,
+        [1000, 200], // Female bin 1, Female bin 2,
+      ],
+    },
   ],
 };
 
-test("Tornado", () => {
+test("Tornado: Horizontal overlay", () => {
   render(
     <TornadoChart
       width={1000}
       height={600}
       groupLayout={EGroupedBarLayout.OVERLAID}
+      direction={EChartDirection.HORIZONTAL}
       showBinPercentages={false}
       data={data}
       id="demo"
     ></TornadoChart>
   );
-  expect(screen.getAllByRole("cell")).toHaveLength(84);
-  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+  expect(screen.getAllByRole("cell")).toHaveLength(8);
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
     "data-percentage",
-    "5.89"
+    "66.67"
   );
-  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
     "d",
-    "m11 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+    "m435 4 h0 v68 h-0 a0 0 0 0 1 -0 -0 v-68 a0,0 0 0 1 0,-0 z"
   );
-  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
     "data-percentage",
-    "5.27"
+    "33.33"
   );
-  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
     "d",
-    "m56 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+    "m435 87 h0 v68 h-0 a0 0 0 0 1 -0 -0 v-68 a0,0 0 0 1 0,-0 z"
   );
-  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
     "data-percentage",
-    "1.34"
+    "50.00"
   );
-  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
     "d",
-    "m101 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+    "m0 4 h0 a0 0 0 0 1 0 0 v68 a0 0 0 0 1 -0 0 h-0  v-68"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "d",
+    "m0 87 h0 a0 0 0 0 1 0 0 v68 a0 0 0 0 1 -0 0 h-0  v-68"
+  );
+});
+
+test("Tornado: Horizontal stacked", () => {
+  render(
+    <TornadoChart
+      width={1000}
+      height={600}
+      groupLayout={EGroupedBarLayout.STACKED}
+      direction={EChartDirection.HORIZONTAL}
+      showBinPercentages={false}
+      data={data}
+      id="demo"
+    ></TornadoChart>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(8);
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "66.67"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "d",
+    "m435 4 h0 v68 h-0 a0 0 0 0 1 -0 -0 v-68 a0,0 0 0 1 0,-0 z"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "33.33"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "d",
+    "m435 87 h0 v68 h-0 a0 0 0 0 1 -0 -0 v-68 a0,0 0 0 1 0,-0 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "d",
+    "m0 4 h0 a0 0 0 0 1 0 0 v68 a0 0 0 0 1 -0 0 h-0  v-68"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "d",
+    "m0 87 h0 a0 0 0 0 1 0 0 v68 a0 0 0 0 1 -0 0 h-0  v-68"
+  );
+});
+
+test("Tornado: Horizontal grouped", () => {
+  render(
+    <TornadoChart
+      width={1000}
+      height={600}
+      groupLayout={EGroupedBarLayout.GROUPED}
+      direction={EChartDirection.HORIZONTAL}
+      showBinPercentages={false}
+      data={data}
+      id="demo"
+    ></TornadoChart>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(8);
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "66.67"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "d",
+    "m435 0 h0 v35 h-0 a0 0 0 0 1 -0 -0 v-35 a0,0 0 0 1 0,-0 z"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "33.33"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "d",
+    "m435 83 h0 v35 h-0 a0 0 0 0 1 -0 -0 v-35 a0,0 0 0 1 0,-0 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "d",
+    "m0 0 h0 a0 0 0 0 1 0 0 v35 a0 0 0 0 1 -0 0 h-0  v-35"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "d",
+    "m0 83 h0 a0 0 0 0 1 0 0 v35 a0 0 0 0 1 -0 0 h-0  v-35"
+  );
+});
+
+////
+
+test("Tornado: Vertical overlay", () => {
+  render(
+    <TornadoChart
+      width={1000}
+      height={600}
+      groupLayout={EGroupedBarLayout.OVERLAID}
+      direction={EChartDirection.VERTICAL}
+      showBinPercentages={false}
+      data={data}
+      id="demo"
+    ></TornadoChart>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(8);
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "33.33"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "d",
+    "m9 235 v0 a0,0 0 0 1 0,-0 h127 a0 0 0 0 1 0 0 v0 h-127 z"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "66.67"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "d",
+    "m166 235 v0 a0,0 0 0 1 0,-0 h127 a0 0 0 0 1 0 0 v0 h-127 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "d",
+    "m9 0 v0 a0 0 0 0 0 0 0 h127 a0 0 0 0 0 0 -0 v0 h-127 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "d",
+    "m166 0 v0 a0 0 0 0 0 0 0 h127 a0 0 0 0 0 0 -0 v0 h-127 z"
+  );
+});
+
+test("Tornado: Vertical stacked", () => {
+  render(
+    <TornadoChart
+      width={1000}
+      height={600}
+      groupLayout={EGroupedBarLayout.STACKED}
+      direction={EChartDirection.VERTICAL}
+      showBinPercentages={false}
+      data={data}
+      id="demo"
+    ></TornadoChart>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(8);
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "33.33"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "d",
+    "m9 235 v0 a0,0 0 0 1 0,-0 h127 a0 0 0 0 1 0 0 v0 h-127 z"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "66.67"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "d",
+    "m166 235 v0 a0,0 0 0 1 0,-0 h127 a0 0 0 0 1 0 0 v0 h-127 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "d",
+    "m9 0 v0 a0 0 0 0 0 0 0 h127 a0 0 0 0 0 0 -0 v0 h-127 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "d",
+    "m166 0 v0 a0 0 0 0 0 0 0 h127 a0 0 0 0 0 0 -0 v0 h-127 z"
+  );
+});
+
+test("Tornado: Vertical grouped", () => {
+  render(
+    <TornadoChart
+      width={1000}
+      height={600}
+      groupLayout={EGroupedBarLayout.GROUPED}
+      direction={EChartDirection.VERTICAL}
+      showBinPercentages={false}
+      data={data}
+      id="demo"
+    ></TornadoChart>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(8);
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "33.33"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-0")).toHaveAttribute(
+    "d",
+    "m2 235 v0 a0,0 0 0 1 0,-0 h67 a0 0 0 0 1 0 0 v0 h-67 z"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "66.67"
+  );
+  expect(screen.getByTestId("chart-bar-left-demo-1")).toHaveAttribute(
+    "d",
+    "m159 235 v0 a0,0 0 0 1 0,-0 h67 a0 0 0 0 1 0 0 v0 h-67 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-0")).toHaveAttribute(
+    "d",
+    "m2 0 v0 a0 0 0 0 0 0 0 h67 a0 0 0 0 0 0 -0 v0 h-67 z"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "data-percentage",
+    "50.00"
+  );
+  expect(screen.getByTestId("chart-bar-right-demo-1")).toHaveAttribute(
+    "d",
+    "m159 0 v0 a0 0 0 0 0 0 0 h67 a0 0 0 0 0 0 -0 v0 h-67 z"
   );
 });

--- a/src/Tornado.spec.tsx
+++ b/src/Tornado.spec.tsx
@@ -1,0 +1,74 @@
+import "@testing-library/jest-dom/extend-expect";
+
+import React from "react";
+
+import { render, screen, within } from "@testing-library/react";
+
+import { barChartData } from "../test/fixtures";
+import { BarChart, EChartDirection } from "./BarChart";
+import { EGroupedBarLayout } from "./Histogram";
+import { Props, TornadoChart } from "./TornadoChart";
+
+beforeEach(() => {
+  (SVGElement.prototype as any).getBBox = () => {
+    return { x: 0, y: 0, width: 0, heigh: 0, bottom: 0, left: 0 };
+  };
+});
+
+const data: Props["data"] = {
+  bins: ["16-18", "18-25", "25-35", "35-50", "50-65", "65-∞"],
+  counts: [
+    {
+      label: "Background",
+      data: [
+        [2001], // Male bin 1, Male bin 2,
+        [2002], // Female bin 1, Female bin 2,
+      ],
+    },
+    // {
+    //   label: "Foreground",
+    //   data: [
+    //     [100, 260, 510, 970, 840, 670], // Male bin 1, Male bin 2,
+    //     [1000, 5500, 470, 870, 490, 140], // Female bin 1, Female bin 2,
+    //   ],
+    // },
+  ],
+};
+
+test("Tornado", () => {
+  render(
+    <TornadoChart
+      width={1000}
+      height={600}
+      groupLayout={EGroupedBarLayout.OVERLAID}
+      showBinPercentages={false}
+      data={data}
+      id="demo"
+    ></TornadoChart>
+  );
+  expect(screen.getAllByRole("cell")).toHaveLength(84);
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "data-percentage",
+    "5.89"
+  );
+  expect(screen.getByTestId("chart-bar--0")).toHaveAttribute(
+    "d",
+    "m11 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "data-percentage",
+    "5.27"
+  );
+  expect(screen.getByTestId("chart-bar--1")).toHaveAttribute(
+    "d",
+    "m56 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+  );
+  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+    "data-percentage",
+    "1.34"
+  );
+  expect(screen.getByTestId("chart-bar--2")).toHaveAttribute(
+    "d",
+    "m101 500 v0 a0 0 0 0 1 0 -0 h19 a0 0 0 0 1 0 0 v0 h-19"
+  );
+});

--- a/src/TornadoChart.tsx
+++ b/src/TornadoChart.tsx
@@ -49,6 +49,10 @@ export type Props = {
   /** @description Chart <title /> */
   title?: string;
   tip?: TipFunc;
+  bars?: {
+    /** @description radius (px) of bar rounded end's curves. Default 0 - no rounded ends */
+    radius?: number;
+  };
 };
 
 export const TornadoChart = ({
@@ -69,6 +73,7 @@ export const TornadoChart = ({
   showBinPercentages = false,
   title,
   tip,
+  bars,
 }: Props) => {
   if (!yAxisWidth) {
     yAxisWidth = direction === EChartDirection.VERTICAL ? 40 : 100;
@@ -140,6 +145,7 @@ export const TornadoChart = ({
         padding={padding}
         showLabels={[showBinPercentages, showBinPercentages]}
         tip={tip}
+        radius={bars?.radius ?? 0}
       />
 
       <Bars
@@ -162,6 +168,7 @@ export const TornadoChart = ({
         padding={padding}
         showLabels={[showBinPercentages, showBinPercentages]}
         tip={tip}
+        radius={bars?.radius ?? 0}
       />
 
       {direction === EChartDirection.HORIZONTAL && (

--- a/src/TornadoChart.tsx
+++ b/src/TornadoChart.tsx
@@ -36,7 +36,7 @@ export type Props = {
   /** @description Height in px of the axis which labels the left/right values */
   splitAxisHeight?: number;
   /** @description labels for the left/right split axis  */
-  splitBins: [string, string];
+  splitBins?: [string, string];
   visible?: Record<string, boolean>;
   xAxisHeight?: number;
   yAxisWidth?: number;
@@ -80,6 +80,9 @@ export const TornadoChart = ({
     splitAxisHeight = direction === EChartDirection.VERTICAL ? 100 : 40;
   }
 
+  if (width === 0) {
+    return null;
+  }
   const domain = calculateDomain(data, true);
   const baseProps = {
     width,
@@ -87,28 +90,6 @@ export const TornadoChart = ({
     chartPadding,
     title,
   };
-
-  const dataSets: any[] = [];
-  data.counts.forEach((count) => {
-    count.data.forEach((value, genderIndex) => {
-      value.forEach((aValue, rowIndex) => {
-        if (!dataSets[rowIndex]) {
-          dataSets[rowIndex] = [];
-        }
-        dataSets[rowIndex].push({
-          side: genderIndex === 0 ? "left" : "right",
-          groupLabel: count.label,
-          colorRef: count.label,
-          label: data.bins[rowIndex],
-          value:
-            visible[data.bins[rowIndex]] !== false &&
-            visible[count.label] !== false
-              ? aValue
-              : 0,
-        });
-      });
-    });
-  });
 
   const left: BarChartDataSet[] = data.counts.map((counts, i) => {
     return {

--- a/src/components/Bars/Bars.tsx
+++ b/src/components/Bars/Bars.tsx
@@ -107,7 +107,7 @@ export const Bars = ({
   rx = 0,
   ry = 0,
 }: Props) => {
-  if (width === 0) {
+  if (width === 0 || height === 0) {
     return null;
   }
   if (!hoverColorScheme) {
@@ -115,7 +115,7 @@ export const Bars = ({
   }
 
   const { dataSets, binLabels } = buildBarDatasets({ values, bins, visible });
-
+  console.log("chart dims", width, height);
   const numericScale = scaleLinear()
     .domain(domain)
     .rangeRound([0, direction === EChartDirection.HORIZONTAL ? width : height]);
@@ -187,23 +187,27 @@ export const Bars = ({
             const showLabel = shouldShowLabel(item, visible, showLabels);
             return (
               <g key={i}>
-                <animated.rect
+                <animated.path
                   ref={refs[i]}
                   role="cell"
                   data-testid={`chart-bar-${id}-${i}`}
                   onMouseEnter={() => setHover(i)}
                   onMouseLeave={() => setHover(-1)}
                   key={`bar-${item.groupLabel}-${item.label}-${item.binIndex}`}
-                  height={props.height}
                   fill={hover == i ? props.hoverFill : props.fill}
+                  data-value={item.value}
+                  data-percentage={item.percentage}
+                  d={props.d}
+                ></animated.path>
+                {/* <animated.rect
+                  height={props.height}
                   width={props.width}
                   rx={rx}
                   ry={ry}
                   x={props.x}
+                  fill="rgba(10, 10, 10, 0.1)"
                   y={props.y}
-                  data-value={item.value}
-                  data-percentage={item.percentage}
-                ></animated.rect>
+                ></animated.rect> */}
                 {showLabel && (
                   <ThisLabel
                     {...props}

--- a/src/components/Bars/Bars.tsx
+++ b/src/components/Bars/Bars.tsx
@@ -50,6 +50,7 @@ export type Props = {
   inverse?: boolean;
   rx?: number;
   ry?: number;
+  radius?: number;
 };
 
 const paddings = {
@@ -106,6 +107,7 @@ export const Bars = ({
   inverse = false,
   rx = 0,
   ry = 0,
+  radius = 4,
 }: Props) => {
   if (width === 0 || height === 0) {
     return null;
@@ -115,7 +117,6 @@ export const Bars = ({
   }
 
   const { dataSets, binLabels } = buildBarDatasets({ values, bins, visible });
-  console.log("chart dims", width, height);
   const numericScale = scaleLinear()
     .domain(domain)
     .rangeRound([0, direction === EChartDirection.HORIZONTAL ? width : height]);
@@ -172,6 +173,7 @@ export const Bars = ({
       paddings,
       values,
       width,
+      radius,
     })
   );
   const ThisLabel = LabelComponent ?? Label;
@@ -199,15 +201,6 @@ export const Bars = ({
                   data-percentage={item.percentage}
                   d={props.d}
                 ></animated.path>
-                {/* <animated.rect
-                  height={props.height}
-                  width={props.width}
-                  rx={rx}
-                  ry={ry}
-                  x={props.x}
-                  fill="rgba(10, 10, 10, 0.1)"
-                  y={props.y}
-                ></animated.rect> */}
                 {showLabel && (
                   <ThisLabel
                     {...props}

--- a/src/components/Bars/HistogramBars.tsx
+++ b/src/components/Bars/HistogramBars.tsx
@@ -145,8 +145,6 @@ export const HistogramBars = ({
               stroke={stroke}
               className="chart-bar"
               role="cell"
-              // rx={rx}
-              // ry={ry}
               d={props.d}
               data-testid={`chart-bar-${id}-${i}`}
               onMouseEnter={() => setHover(i)}
@@ -154,7 +152,6 @@ export const HistogramBars = ({
               key={`bar-${item.groupLabel}.${item.label}.${item.value}`}
               height={props.height}
               fill={hover == i ? props.hoverFill : props.fill}
-              // width={props.width}
               x={props.x}
               y={props.y}
             >
@@ -163,6 +160,7 @@ export const HistogramBars = ({
                   {...props}
                   label={labels?.[i]}
                   item={dataSets[i]}
+                  containerHeight={height}
                   fill={props.fill.get()}
                   direction={direction}
                 />

--- a/src/components/Bars/HistogramBars.tsx
+++ b/src/components/Bars/HistogramBars.tsx
@@ -37,8 +37,7 @@ type Props = {
   values: BarChartDataSet[];
   visible?: Record<string, boolean>;
   width: number;
-  rx?: number;
-  ry?: number;
+  radius?: number;
 };
 
 export const HistogramBars = ({
@@ -63,8 +62,7 @@ export const HistogramBars = ({
   values,
   visible = {},
   width,
-  rx = 0,
-  ry = 0,
+  radius = 0,
 }: Props) => {
   if (width === 0) {
     return null;
@@ -137,27 +135,28 @@ export const HistogramBars = ({
   return (
     <>
       <g className="bars" transform={`translate${transform}`}>
-        {springs.map((props: any, i) => {
+        {springs.map((props, i) => {
           const item = dataSets[i];
           const showLabel = shouldShowLabel(item, visible, showLabels);
           refs[i] = React.createRef<any>();
           return (
-            <animated.rect
+            <animated.path
               ref={refs[i]}
               stroke={stroke}
               className="chart-bar"
               role="cell"
-              rx={rx}
-              ry={ry}
+              // rx={rx}
+              // ry={ry}
+              d={props.d}
               data-testid={`chart-bar-${id}-${i}`}
               onMouseEnter={() => setHover(i)}
               onMouseLeave={() => setHover(-1)}
               key={`bar-${item.groupLabel}.${item.label}.${item.value}`}
               height={props.height}
               fill={hover == i ? props.hoverFill : props.fill}
-              width={props.width}
-              x={props.x as any}
-              y={props.y as any}
+              // width={props.width}
+              x={props.x}
+              y={props.y}
             >
               {showLabel && (
                 <ThisLabel
@@ -168,7 +167,7 @@ export const HistogramBars = ({
                   direction={direction}
                 />
               )}
-            </animated.rect>
+            </animated.path>
           );
         })}
       </g>

--- a/src/components/Bars/barHelper.ts
+++ b/src/components/Bars/barHelper.ts
@@ -407,11 +407,7 @@ export const getValueOffset = (
     props;
   const offSet = dataSets
     .filter((d) => d.label === item.label)
-    .filter((_, i) =>
-      direction === EChartDirection.HORIZONTAL
-        ? i < item.datasetIndex
-        : i < item.datasetIndex
-    )
+    .filter((_, i) => i < item.datasetIndex)
     .reduce((p, n) => p + n.value, 0);
 
   if (direction === EChartDirection.HORIZONTAL) {

--- a/src/components/Bars/barHelper.ts
+++ b/src/components/Bars/barHelper.ts
@@ -22,7 +22,7 @@ const getBandPosition = (
   props: BarSpringProps,
   itemWidths: number[]
 ) => {
-  const { innerScaleBand, innerDomain, groupLayout, paddings } = props;
+  const { innerScaleBand, innerDomain, groupLayout } = props;
   const groupLabel = item.groupLabel ?? "main";
   let bandX = 0;
   switch (groupLayout) {
@@ -70,6 +70,7 @@ export type BarSpringProps = {
   /** @description - inverse the bars e.g if direction = horizontal run the bars from right to left */
   inverse?: boolean;
   itemWidths: number[];
+  radius?: number;
 };
 /**
  * Build the from / to spring animation properties to animate the bars.
@@ -86,11 +87,16 @@ export const buildBarSprings = (props: BarSpringProps) => {
     hoverColorScheme,
     inverse = false,
     itemWidths,
+    radius = 4,
   } = props;
   const [_, width] = numericScale.range();
   const concreteHoverScheme = hoverColorScheme ?? colorScheme;
-
-  const s = dataSets.map((item) => {
+  const maxDatasetIndex = dataSets.reduce(
+    (prev, next) => (next.datasetIndex > prev ? next.datasetIndex : prev),
+    0
+  );
+  const s = dataSets.map((item, i) => {
+    const outerDataset = item.datasetIndex === maxDatasetIndex;
     const bandValue = Number(bandScale(item.label));
     const bandPosition = getBandPosition(item, props, itemWidths);
     const valueOffset = getValueOffset(item, props);
@@ -99,103 +105,281 @@ export const buildBarSprings = (props: BarSpringProps) => {
     const hoverFill = getFill(
       getSchemeItem(concreteHoverScheme, item.datasetIndex)
     );
-    const radius = 10;
+
     const fill = getFill(getSchemeItem(colorScheme, item.datasetIndex));
-    if (direction === EChartDirection.HORIZONTAL) {
-      const fromX = inverse ? width : 0;
-      const fromY = bandPosition + bandValue;
-      const r = radius * 2 < itemWidth ? radius : 0;
-      const toX = inverse ? width - itemHeight + valueOffset + r : valueOffset;
-      const toY = bandPosition + bandValue;
-      const { topRightCurve, topLeftCurve, bottomLeftCurve, bottomRightCurve } =
-        makeCurves(r);
 
-      const vertical = inverse ? itemWidth : itemWidth - 2 * r;
-      const horizontal = itemHeight - r;
-
-      const startD = inverse
-        ? `m${fromX} ${fromY} h${0} v${vertical} h-${0} ${bottomLeftCurve} v-${
-            vertical - 2 * radius
-          } ${topLeftCurve} z`
-        : `m${fromX} ${fromY} h${0} ${topRightCurve} v${vertical} ${bottomRightCurve} h-${0}  v-${vertical}`;
-
-      const endD = inverse
-        ? `m${toX} ${toY} h${horizontal} v${vertical} h-${horizontal} ${bottomLeftCurve} v-${
-            vertical - 2 * radius
-          } ${topLeftCurve} z`
-        : `m${toX} ${toY} h${horizontal} ${topRightCurve} v${vertical} ${bottomRightCurve} h-${horizontal} v-${vertical}`;
-      return {
-        from: {
-          width: 0,
-          d: startD,
-          fill,
-          hoverFill,
-          x: inverse ? width : 0,
-          y: bandPosition + bandValue,
-          height: itemWidth,
-        },
-        to: {
-          width: itemHeight,
-          d: endD,
-          fill,
-          hoverFill,
-          x: toX,
-          y: bandPosition + bandValue,
-          height: itemWidth,
-        },
-        config,
-      };
-    }
-    console.log("itemWidth", itemWidth);
-    console.log("itemHeight", itemHeight);
-    const r = radius * 2 < itemHeight ? radius : itemHeight / 2;
-
-    const fromX = bandPosition + bandValue;
-    const toX = bandPosition + bandValue;
-    const fromY = inverse ? 0 : height;
-    const toY = inverse ? 0 : valueOffset;
-
-    const vertical = itemHeight - r;
-    const horizontal = inverse ? itemWidth : itemWidth - 2 * r;
-
-    const { topRightCurve, topLeftCurve, bottomLeftCurve, bottomRightCurve } =
-      makeCurves(r);
-
-    const startD = inverse
-      ? `m${fromX} ${fromY} h${horizontal} v0 ${bottomRightCurve} h-${
-          horizontal - 2 * radius
-        } ${bottomLeftCurve} v0 z`
-      : `m${fromX} ${fromY} v0 ${topLeftCurve} h${horizontal} ${topRightCurve} v0 h-${horizontal}`;
-
-    const endD = inverse
-      ? `m${toX} ${toY} h${horizontal} v${vertical} ${bottomRightCurve} h-${
-          horizontal - 2 * radius
-        } ${bottomLeftCurve}  v-${vertical} z`
-      : `m${fromX} ${fromY} v-${vertical} ${topLeftCurve} h${horizontal} ${topRightCurve} v${vertical} h-${horizontal}`;
-
-    return {
-      from: {
-        height: 0,
-        fill,
-        hoverFill,
-        d: startD,
-        x: fromX,
-        y: fromY,
-        width: itemWidth,
-      },
-      to: {
-        height: itemHeight,
-        fill,
-        hoverFill,
-        d: endD,
-        x: toX,
-        y: toY,
-        width: itemWidth,
-      },
+    const builderProps = {
+      bandPosition,
+      bandValue,
       config,
+      fill,
+      hoverFill,
+      itemHeight,
+      itemWidth,
+      radius:
+        props.groupLayout === EGroupedBarLayout.STACKED && !outerDataset
+          ? 0
+          : radius,
+      valueOffset,
+      width,
+      height,
     };
+    if (direction === EChartDirection.HORIZONTAL) {
+      if (!inverse) {
+        return horizontalSpring(builderProps);
+      } else {
+        return horizontalInverseSpring(builderProps);
+      }
+    } else {
+      if (!inverse) {
+        return verticalSpring(builderProps);
+      } else {
+        return verticalInverseSpring(builderProps);
+      }
+    }
   });
   return s;
+};
+
+type FnProps = {
+  itemHeight: number;
+  itemWidth: number;
+  radius: number;
+  bandPosition: number;
+  bandValue: number;
+  valueOffset: number;
+  fill: string;
+  hoverFill: string;
+  config: SpringConfig;
+  width: number;
+  height: number;
+};
+
+const horizontalSpring = ({
+  itemHeight,
+  itemWidth,
+  radius,
+  bandPosition,
+  bandValue,
+  valueOffset,
+  fill,
+  hoverFill,
+  config,
+}: FnProps) => {
+  /**
+   *  from(x,y)                                                 to(x,y)
+   *  ----------------------------------------------------------                -
+   *  |   |                                                 |   |               |
+   *  |___|                                                 |___|  _            |
+   *  | r                                                     r |  |            |
+   *  |                                                         |  | vertical   | itemWidth
+   *  |                                                         |  |            |
+   *  |___                                                   ___|  _            |
+   *  |   |                                                 |   |               |
+   *  |   |                                                 |   |               |
+   *  ----------------------------------------------------------                -
+   *      <--------------------horizontal------------------>
+   *  <----------------------------itemHeight-------------------->
+   */
+  const vertical = itemWidth;
+  const horizontal = itemHeight;
+  let r = radius * 2 < itemHeight ? radius : itemHeight / 2;
+
+  const { topRightCurve, bottomRightCurve } = makeCurves(r);
+
+  const from = {
+    x: 0,
+    y: bandPosition + bandValue,
+  };
+  const to = {
+    x: valueOffset,
+    y: bandPosition + bandValue,
+  };
+
+  return {
+    from: {
+      width: 0,
+      d: `m${from.x} ${from.y} h${0} ${topRightCurve} v${
+        vertical - 2 * r
+      } ${bottomRightCurve} h-${0}  v-${vertical - 2 * r}`,
+      fill,
+      hoverFill,
+      x: 0,
+      y: bandPosition + bandValue,
+      height: itemWidth,
+    },
+    to: {
+      width: itemHeight,
+      d: `m${to.x} ${to.y} h${horizontal - r} ${topRightCurve} v${
+        vertical - 2 * r
+      } ${bottomRightCurve} h-${horizontal - r} v-${vertical - 2 * r}`,
+      fill,
+      hoverFill,
+      x: to.x,
+      y: bandPosition + bandValue,
+      height: itemWidth,
+    },
+    config,
+  };
+};
+
+const horizontalInverseSpring = ({
+  itemHeight,
+  itemWidth,
+  radius,
+  width,
+  bandPosition,
+  bandValue,
+  valueOffset,
+  fill,
+  hoverFill,
+  config,
+}: FnProps) => {
+  const vertical = itemWidth;
+  const horizontal = itemHeight;
+
+  const r = radius * 2 < horizontal ? radius : horizontal / 2;
+  const { topLeftCurve, bottomLeftCurve } = makeCurves(r);
+  const from = {
+    x: width,
+    y: bandPosition + bandValue,
+  };
+  const to = {
+    x: width - horizontal + valueOffset + r,
+    y: bandPosition + bandValue,
+  };
+
+  return {
+    from: {
+      width: 0,
+      d: `m${from.x} ${from.y} h${0} v${vertical} h-${0} ${bottomLeftCurve} v-${
+        vertical - 2 * r
+      } ${topLeftCurve} z`,
+      fill,
+      hoverFill,
+      x: width,
+      y: bandPosition + bandValue,
+      height: vertical,
+    },
+    to: {
+      width: horizontal,
+      d: `m${to.x} ${to.y} h${horizontal - r} v${vertical} h-${
+        horizontal - r
+      } ${bottomLeftCurve} v-${vertical - 2 * r} ${topLeftCurve} z`,
+      fill,
+      hoverFill,
+      x: to.x,
+      y: bandPosition + bandValue,
+      height: vertical,
+    },
+    config,
+  };
+};
+
+const verticalSpring = ({
+  itemHeight,
+  itemWidth,
+  radius,
+  bandPosition,
+  bandValue,
+  valueOffset,
+  fill,
+  height,
+  hoverFill,
+  config,
+}: FnProps) => {
+  const vertical = itemHeight;
+  const horizontal = itemWidth;
+
+  const r = radius * 2 < vertical ? radius : vertical / 2;
+  const { topLeftCurve, topRightCurve } = makeCurves(r);
+  const from = {
+    x: bandPosition + bandValue,
+    y: height,
+  };
+  const to = {
+    x: bandPosition + bandValue,
+    y: valueOffset,
+  };
+
+  return {
+    from: {
+      height: 0,
+      fill,
+      hoverFill,
+      d: `m${from.x} ${from.y} v0 ${topLeftCurve} h${
+        horizontal - 2 * r
+      } ${topRightCurve} v0 h-${horizontal} z`,
+      x: from.x,
+      y: from.y,
+      width: itemWidth,
+    },
+    to: {
+      height: itemHeight,
+      fill,
+      hoverFill,
+      d: `m${to.x} ${to.y} v-${vertical} ${topLeftCurve} h${
+        horizontal - 2 * r
+      } ${topRightCurve} v${vertical} h-${horizontal} z`,
+      x: to.x,
+      y: to.y,
+      width: itemWidth,
+    },
+    config,
+  };
+};
+
+const verticalInverseSpring = ({
+  itemHeight,
+  itemWidth,
+  radius,
+  bandPosition,
+  bandValue,
+  valueOffset,
+  fill,
+  hoverFill,
+  config,
+}: FnProps) => {
+  const vertical = itemHeight;
+  const horizontal = itemWidth;
+  const r = radius * 2 < vertical ? radius : vertical / 2;
+
+  const from = {
+    x: bandPosition + bandValue,
+    y: 0,
+  };
+  const to = {
+    x: bandPosition + bandValue,
+    y: valueOffset,
+  };
+
+  const bottomRightCurve = `a${r} ${r} 0 0 0 ${r} -${r}`;
+  const bottomLeftCurve = `a${r} ${r} 0 0 0 ${r} ${r}`;
+  return {
+    from: {
+      height: 0,
+      fill,
+      hoverFill,
+      d: `m${from.x} ${from.y} v0 ${bottomLeftCurve} h${
+        horizontal - 2 * r
+      } ${bottomRightCurve} v0 h-${horizontal} z`,
+      x: from.x,
+      y: from.y,
+      width: itemWidth,
+    },
+    to: {
+      height: itemHeight,
+      fill,
+      hoverFill,
+      d: `m${to.x} ${to.y} v${vertical} ${bottomLeftCurve} h${
+        horizontal - 2 * r
+      } ${bottomRightCurve}  v-${vertical} h-${horizontal} z`,
+      x: to.x,
+      y: to.y,
+      width: itemWidth,
+    },
+    config,
+  };
 };
 
 const makeCurves = (radius: number) => {
@@ -211,7 +395,7 @@ const makeCurves = (radius: number) => {
   };
 };
 /**
- * If we are using a STACKED group layout the work out the total height
+ * If we are using a STACKED group layout then work out the total height
  * of the bars which should be stacked under the current item.
  * This should provide us with the finishing location for the bar's y position.
  */
@@ -219,13 +403,14 @@ export const getValueOffset = (
   item: ExtendedGroupItem,
   props: BarSpringProps
 ) => {
-  const { direction, numericScale, groupLayout, height, dataSets } = props;
+  const { direction, numericScale, groupLayout, height, dataSets, inverse } =
+    props;
   const offSet = dataSets
     .filter((d) => d.label === item.label)
     .filter((_, i) =>
       direction === EChartDirection.HORIZONTAL
         ? i < item.datasetIndex
-        : i <= item.datasetIndex
+        : i < item.datasetIndex
     )
     .reduce((p, n) => p + n.value, 0);
 
@@ -233,14 +418,13 @@ export const getValueOffset = (
     if (groupLayout !== EGroupedBarLayout.STACKED) {
       return 0;
     }
-    return numericScale(offSet);
+    return numericScale(offSet) * (inverse ? -1 : 1);
   }
 
   if (groupLayout !== EGroupedBarLayout.STACKED) {
-    return height - numericScale(item.value);
+    return inverse ? 0 : height;
   }
-
-  return height - numericScale(offSet);
+  return inverse ? 0 + numericScale(offSet) : height - numericScale(offSet);
 };
 
 export const shouldShowLabel = (

--- a/src/components/Bars/histogramHelper.ts
+++ b/src/components/Bars/histogramHelper.ts
@@ -117,11 +117,9 @@ const horizontalSpring = ({
   return {
     from: {
       width: 0,
-
       d: `m${from.x} ${from.y} h${0} ${topRightCurve} v${
         vertical - 2 * r
       } ${bottomRightCurve} h-${0}  v-${vertical - 2 * r}`,
-
       fill,
       hoverFill,
       x: 0,
@@ -132,7 +130,6 @@ const horizontalSpring = ({
       d: `m${to.x} ${to.y} h${horizontal - r} ${topRightCurve} v${
         vertical - 2 * r
       } ${bottomRightCurve} h-${horizontal - r} v-${vertical - 2 * r}`,
-
       width: itemHeight,
       fill,
       hoverFill,

--- a/src/components/Bars/histogramHelper.ts
+++ b/src/components/Bars/histogramHelper.ts
@@ -4,7 +4,7 @@ import { SpringConfig } from "@react-spring/web";
 
 import { EChartDirection } from "../../BarChart";
 import { BarChartDataSet } from "../../Histogram";
-import { ColorScheme } from "../../utils/colorScheme";
+import { ColorScheme, ColorSchemeItem } from "../../utils/colorScheme";
 import { ExtendedGroupItem } from "./Bars";
 
 type HistogramSpringProps = {
@@ -19,6 +19,7 @@ type HistogramSpringProps = {
   hoverColorScheme?: ColorScheme;
   config: SpringConfig;
   direction: EChartDirection;
+  radius?: number;
 };
 /**
  * Build the from / to spring animation properties to animate the bars.
@@ -34,6 +35,7 @@ export const buildHistogramSprings = (props: HistogramSpringProps) => {
     continuousScale,
     colorScheme,
     hoverColorScheme,
+    radius = 4,
   } = props;
   const s = dataSets.map((item, index) => {
     const bandPosition = continuousScale(bins[index][0]);
@@ -44,56 +46,148 @@ export const buildHistogramSprings = (props: HistogramSpringProps) => {
     const itemWidth = continuousScale(binWidth + startValue);
 
     const itemHeight = numericScale(item.value);
+    const fill = colorScheme[item.datasetIndex];
+    const hoverFill =
+      hoverColorScheme?.[item.datasetIndex] ?? colorScheme[item.datasetIndex];
 
     if (direction === EChartDirection.HORIZONTAL) {
-      return {
-        from: {
-          width: 0,
-          fill: colorScheme[item.datasetIndex],
-          hoverFill:
-            hoverColorScheme?.[item.datasetIndex] ??
-            colorScheme[item.datasetIndex],
-          x: 0,
-          y: height - itemWidth - bandPosition,
-          height: itemWidth,
-        },
-        to: {
-          width: itemHeight,
-          fill: colorScheme[item.datasetIndex],
-          hoverFill:
-            hoverColorScheme?.[item.datasetIndex] ??
-            colorScheme[item.datasetIndex],
-          x: 0,
-          y: height - itemWidth - bandPosition,
-          height: itemWidth,
-        },
+      return horizontalSpring({
+        fill,
+        hoverFill,
+        bandPosition,
+        height,
+        itemWidth,
         config,
-      };
+        itemHeight,
+        radius,
+      });
     }
 
-    return {
-      from: {
-        height: 0,
-        fill: colorScheme[item.datasetIndex],
-        hoverFill:
-          hoverColorScheme?.[item.datasetIndex] ??
-          colorScheme[item.datasetIndex],
-        x: bandPosition,
-        y: height,
-        width: itemWidth,
-      },
-      to: {
-        height: itemHeight,
-        fill: colorScheme[item.datasetIndex],
-        hoverFill:
-          hoverColorScheme?.[item.datasetIndex] ??
-          colorScheme[item.datasetIndex],
-        x: bandPosition,
-        y: height - itemHeight,
-        width: itemWidth,
-      },
+    return verticalSpring({
+      fill,
+      hoverFill,
+      bandPosition,
+      height,
+      itemWidth,
       config,
-    };
+      itemHeight,
+      radius,
+    });
   });
   return s;
+};
+
+type FnProps = {
+  fill: ColorSchemeItem;
+  hoverFill: ColorSchemeItem;
+  bandPosition: number;
+  height: number;
+  itemWidth: number;
+  itemHeight: number;
+  config: SpringConfig;
+  radius: number;
+};
+
+const horizontalSpring = ({
+  fill,
+  hoverFill,
+  bandPosition,
+  height,
+  itemWidth,
+  itemHeight,
+  config,
+  radius,
+}: FnProps) => {
+  const from = {
+    x: 0,
+    y: height - itemWidth - bandPosition,
+  };
+
+  const to = {
+    x: 0,
+    y: height - itemWidth - bandPosition,
+  };
+  let r = radius * 2 < itemHeight ? radius : itemHeight / 2;
+  const topRightCurve = `a${r} ${r} 0 0 1 ${r} ${r}`;
+  const bottomRightCurve = `a${r} ${r} 0 0 1 -${r} ${r}`;
+  const vertical = itemWidth;
+  const horizontal = itemHeight;
+
+  return {
+    from: {
+      width: 0,
+
+      d: `m${from.x} ${from.y} h${0} ${topRightCurve} v${
+        vertical - 2 * r
+      } ${bottomRightCurve} h-${0}  v-${vertical - 2 * r}`,
+
+      fill,
+      hoverFill,
+      x: 0,
+      y: height - itemWidth - bandPosition,
+      height: itemWidth,
+    },
+    to: {
+      d: `m${to.x} ${to.y} h${horizontal - r} ${topRightCurve} v${
+        vertical - 2 * r
+      } ${bottomRightCurve} h-${horizontal - r} v-${vertical - 2 * r}`,
+
+      width: itemHeight,
+      fill,
+      hoverFill,
+      x: 0,
+      y: height - itemWidth - bandPosition,
+      height: itemWidth,
+    },
+    config,
+  };
+};
+
+const verticalSpring = ({
+  fill,
+  hoverFill,
+  bandPosition,
+  height,
+  itemWidth,
+  itemHeight,
+  config,
+  radius,
+}: FnProps) => {
+  const r = radius * 2 < itemWidth ? radius : itemWidth / 2;
+  const topLeftCurve = `a${r},${r} 0 0 1 ${r},-${r}`;
+  const topRightCurve = `a${r} ${r} 0 0 1 ${r} ${r}`;
+
+  const from = {
+    x: bandPosition,
+    y: height,
+  };
+  const to = {
+    x: bandPosition,
+    y: height,
+  };
+  return {
+    from: {
+      height: 0,
+      d: `m${from.x} ${from.y} v0 ${topLeftCurve} h${
+        itemWidth - 2 * r
+      } ${topRightCurve} v0 h-${itemHeight} z`,
+      fill,
+      hoverFill,
+      x: bandPosition,
+      y: height,
+      width: itemWidth,
+    },
+    to: {
+      height: itemHeight,
+      d: `m${to.x} ${to.y} v-${itemHeight} ${topLeftCurve} h${
+        itemWidth - 2 * r
+      } ${topRightCurve} v${itemHeight} h-${itemWidth} z`,
+      fill,
+      hoverFill,
+      x: bandPosition,
+      y: height - itemHeight,
+      width: itemWidth,
+    },
+    config,
+  };
 };

--- a/src/components/Bars/histogramHelper.ts
+++ b/src/components/Bars/histogramHelper.ts
@@ -4,7 +4,7 @@ import { SpringConfig } from "@react-spring/web";
 
 import { EChartDirection } from "../../BarChart";
 import { BarChartDataSet } from "../../Histogram";
-import { ColorScheme, ColorSchemeItem } from "../../utils/colorScheme";
+import { ColorScheme, getFill } from "../../utils/colorScheme";
 import { ExtendedGroupItem } from "./Bars";
 
 type HistogramSpringProps = {
@@ -46,9 +46,10 @@ export const buildHistogramSprings = (props: HistogramSpringProps) => {
     const itemWidth = continuousScale(binWidth + startValue);
 
     const itemHeight = numericScale(item.value);
-    const fill = colorScheme[item.datasetIndex];
-    const hoverFill =
-      hoverColorScheme?.[item.datasetIndex] ?? colorScheme[item.datasetIndex];
+    const fill = getFill(colorScheme[item.datasetIndex]);
+    const hoverFill = getFill(
+      hoverColorScheme?.[item.datasetIndex] ?? colorScheme[item.datasetIndex]
+    );
 
     if (direction === EChartDirection.HORIZONTAL) {
       return horizontalSpring({
@@ -78,8 +79,8 @@ export const buildHistogramSprings = (props: HistogramSpringProps) => {
 };
 
 type FnProps = {
-  fill: ColorSchemeItem;
-  hoverFill: ColorSchemeItem;
+  fill: string;
+  hoverFill: string;
   bandPosition: number;
   height: number;
   itemWidth: number;


### PR DESCRIPTION
* replace the Bars/bars helpers logic with code to render svg paths with arcs as rounded corners. 
* Fixed Tornado charts rendering at width 0 which created interesting animations. Now animations won't start until the chart width and height are not 0
* Added some extra tests to capture the correct layout for the bars 
![image](https://github.com/infosum/cl-react-graph/assets/28268/c0318368-4cd4-44ab-a197-83546f0676d9)
